### PR TITLE
Fix calculator scientific notation responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@
                                 <!-- Display -->
                                 <div class="rounded-lg bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 p-3">
                                     <div id="calc-history" class="h-5 text-xs text-right text-gray-500 dark:text-gray-400 truncate"></div>
-                                    <input id="calc-display" type="text" inputmode="none" tabindex="0" aria-readonly="true" class="w-full bg-transparent text-right text-2xl font-semibold text-gray-900 dark:text-gray-100 focus:outline-none overflow-hidden caret-primary-500" placeholder="0" aria-label="Calculator input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+                                    <input id="calc-display" type="text" inputmode="none" tabindex="0" aria-readonly="true" class="w-full bg-transparent text-left sm:text-right text-xl sm:text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100 focus:outline-none caret-primary-500" placeholder="0" aria-label="Calculator input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
                                     
                                 </div>
                                 <!-- Caret navigation controls -->


### PR DESCRIPTION
Adjust calculator display responsiveness to show scientific notation on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-25f1eada-3f7f-4fab-8d1b-77a921533ee8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25f1eada-3f7f-4fab-8d1b-77a921533ee8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

